### PR TITLE
rubocopのCIを作成する

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: lint
-on: [push, pull_request]
+on: push
 jobs:
   rubocop:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: 3.1.2
+          bundler: 2.3.7
           bundler-cache: true
       - run: bundle install
       - name: RuboCop実行

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1.2
           bundler-cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,6 @@ jobs:
         with:
           ruby-version: 3.1.2
           bundler-cache: true
+      - run: bundle install
       - name: RuboCop実行
         run: bundle exec rubocop --parallel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: 3.1.2
-          bundler: 2.3.7
           bundler-cache: true
       - run: bundle install
       - name: RuboCop実行

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,5 @@ jobs:
         with:
           ruby-version: 3.1.2
           bundler-cache: true
-      - run: bundle install
       - name: RuboCop実行
         run: bundle exec rubocop --parallel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: lint
+on: [push, pull_request]
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.1.2
+          bundler-cache: true
+      - name: RuboCop実行
+        run: bundle exec rubocop --parallel

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_gem:
     - "config/rspec.yml"
 
 AllCops:
-  TargetRubyVersion: 3.1.2
+  TargetRubyVersion: 3.1
   # comment unless use rails cops
   TargetRailsVersion: 7.0
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_gem:
     - "config/rspec.yml"
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.1.2
   # comment unless use rails cops
   TargetRailsVersion: 7.0
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,4 @@ AllCops:
   TargetRailsVersion: 7.0
   Exclude:
     - bin/bundle
+    - vendor/**/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -192,6 +194,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   debug

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,5 @@
 
 ActiveRecord::Schema[7.0].define(version: 0) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
+  enable_extension 'plpgsql'
 end


### PR DESCRIPTION
# やること
pushしたときに自動的にrubocopが走るようにCIを設定する

関連PR: https://github.com/smptmhr/el-training/pull/7
参考: https://github.com/ruby/setup-ruby#single-job

# 完了条件
- [x] github actionsでrubocopが正常に動作する
- [x] このPRで `All checks have passed` になっている

# エラーが発生したので修正したこと
github actionsでbundle install時に下記のエラーが発生
```
Your bundle only supports platforms ["x86_64-darwin-19"] but your local platform
  is x86_64-linux. Add the current platform to the lockfile with `bundle lock
  --add-platform x86_64-linux` and try again.
```

`x86_64-linux` を追加する必要があるので `bundle lock --add-platform x86_64-linux` コマンドを実行した

また、`Unable to find gem rubocop-discourse; is the gem installed? Gem::MissingSpecError` というエラーが発生
`vendor/**/*` にgemがinstallされる関係上、除外することでエラーを取り除く
https://qiita.com/pensuke628/items/eadfba5609aa0d4e5097