### PR TITLE
Step11 アプリを日本語に対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'enum_help'
 gem 'importmap-rails', '~> 1.1'
 gem 'turbo-rails'
 
+gem 'rails-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i(mri mingw x64_mingw)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.2.3)
       actionpack (= 7.0.2.3)
       activesupport (= 7.0.2.3)
@@ -277,6 +280,7 @@ DEPENDENCIES
   pg
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)
+  rails-i18n
   retrieva-cop
   rspec-rails
   selenium-webdriver

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,8 +1,5 @@
 <% if @task.errors.any? %>
   <div id="error_explanation">
-    <div class="alert alert-danger">
-      The form contains <%= pluralize(@task.errors.count, "error") %>.
-    </div>
     <ul>
     <% @task.errors.full_messages.each do |msg| %>
       <li><%= msg %></li>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -8,6 +8,7 @@
   <%= f.label      :description %>
   <%= f.text_area  :description, class: 'form-control' %>
 
+
   <%= f.label      :start_date %>
   <%= f.date_field :start_date,  class: 'form-control' %>
 

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,3 +1,4 @@
+<h1><%= I18n.t('task_edit') %></h1>
 <% provide(:button_text, I18n.t('save_changes')) %>
 <div class="row">
   <div class="col-md-6 col-md-offset-3">

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,4 +1,4 @@
-<% provide(:button_text, "Save changes") %>
+<% provide(:button_text, I18n.t('save_changes')) %>
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= render 'form' %>
@@ -6,5 +6,5 @@
 </div>
 
 <div class = "col-md-offset-3">
-  <%=link_to "編集をキャンセル", @task%>
+  <%=link_to  I18n.t('cancel_edit'), @task%>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<h1>All tasks</h1>
+<h1><%= I18n.t('task_index') %></h1>
 <div><%= link_to I18n.t('create_task'), new_task_url %>
 <br>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,42 +1,42 @@
 <h1>All tasks</h1>
-<div><%= link_to 'タスクを作成', new_task_url %>
+<div><%= link_to I18n.t('create_task'), new_task_url %>
 <br>
 
 <ul class="tasks">
   <% @tasks.each do |task| %>
     <li>
       <div>
-        <span>タスク名</span>
+        <span><%= Task.human_attribute_name(:name) %></span>
         <span><%= task.name%></span>
-        <span><%= link_to "詳細",  task %></span>
+        <span><%= link_to I18n.t('detail'),  task %></span>
       </div>
 
       <% if task.description.present? %>
         <div>
-          <span>説明文</span>
+          <span><%= Task.human_attribute_name(:description) %></span>
           <%= task.description %>
         </div>
       <% end %>
 
       <div>
-        <span>必要日数</span>
+        <span><%= Task.human_attribute_name(:necessary_days) %></span>
         <%= task.necessary_days %>日
       </div>
 
       <div>
-        <span>取り掛かり期間</span>
+        <span><%= Task.human_attribute_name(:period_on_task) %></span>
         <%  deadline_date = task.start_date + task.necessary_days - 1  %>
         <%= print_month_day_wday task.start_date %> ~ 
         <%= print_month_day_wday deadline_date %>
       </div>
 
       <div>
-        <span>実行状況</span>
+        <span><%= Task.human_attribute_name(:progress) %></span>
         <%= task.progress %>
       </div>
       
       <div>
-        <span>重要度</span>
+        <span><%= Task.human_attribute_name(:priority) %></span>
         <%= task.priority%>
       </div>
       

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,6 +1,5 @@
 <h1><%= I18n.t('task_create') %></h1>
 <% provide(:button_text, "Create") %>
-<h1>new task</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,3 +1,4 @@
+<h1><%= I18n.t('task_create') %></h1>
 <% provide(:button_text, "Create") %>
 <h1>new task</h1>
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -8,5 +8,5 @@
 </div>
 
 <div class = "col-md-offset-3">
-  <%=link_to "作成をキャンセル", tasks_url%>
+  <%=link_to I18n.t('cancel_create'), tasks_url%>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,9 +1,9 @@
 <div class = "col-md-offset-1">
-  <span><%= link_to "一覧に戻る",  tasks_url      %></span>
-  <span><%= link_to "編集",       edit_task_path %></span>
+  <span><%= link_to  I18n.t('back_to_index'),  tasks_url      %></span>
+  <span><%= link_to  I18n.t('edit'),           edit_task_path %></span>
   <span>
-    <%= button_to "タスクを削除", @task, method: :delete,
-                      form: {data: {turbo_confirm: "本当に削除しますか?"} } %> 
+    <%= button_to I18n.t('delete_task'), @task, method: :delete,
+                      form: {data: {turbo_confirm: I18n.t('message_before_delete')} } %> 
   </span>
 </div>
 
@@ -13,36 +13,36 @@
   <div class="col-md-8 col-md-offset-1">
 
     <div>
-      <span>タスク名</span>
+      <span><%= Task.human_attribute_name(:name) %></span>
       <%= @task.name %>
     </div>
 
     <% if @task.description.present? %>
       <div>
-        <span>説明</span>
+        <span><%= Task.human_attribute_name(:description) %></span>
         <%= @task.description %>
       </div>
     <% end %>
 
     <div>
-      <span>必要日数</span>
+      <span><%= Task.human_attribute_name(:necessary_days) %></span>
       <%= @task.necessary_days %>日
     </div>
     
     <div>
-      <span>取り掛かり期間</span>
+      <span><%= Task.human_attribute_name(:period_on_task) %></span>
       <%  @deadline_date = @task.start_date + @task.necessary_days - 1 %>
       <%= print_month_day_wday @task.start_date %> ~ 
       <%= print_month_day_wday @deadline_date %>
     </div>
 
     <div>
-      <span>実行状況</span>
+      <span><%= Task.human_attribute_name(:progress) %></span>
       <%= @task.progress %>
     </div>
     
     <div>
-      <span>重要度</span>
+      <span><%= Task.human_attribute_name(:priority) %></span>
       <%= @task.priority %>
     </div>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,5 @@
 <div class = "col-md-offset-1">
+  <h1><%= @task.name %></h1>
   <span><%= link_to  I18n.t('back_to_index'),  tasks_url      %></span>
   <span><%= link_to  I18n.t('edit'),           edit_task_path %></span>
   <span>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,13 +28,16 @@ module TaskApp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    
+
     # タイムゾーンを設定
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
 
     # デフォルト言語を日本語に設定
     config.i18n.default_locale = :ja
+
+    # i18nの複数ロケールファイルが読み込まれるようpathを通す
+    config.i18n.load_path += Dir[Rails.root.join('path/to').to_s]
 
     # config.eager_load_paths << Rails.root.join("extras")
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,14 @@ module TaskApp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    
+    # タイムゾーンを設定
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+
+    # デフォルト言語を日本語に設定
+    config.i18n.default_locale = :ja
+
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,22 @@
+ja:
+  # フラッシュメッセージ
+  task_create_success: "タスクを作成しました"
+  task_create_failed:  "タスクの作成に失敗しました"
+  task_update_success: "タスクを更新しました"
+  task_update_failed:  "タスクの更新に失敗しました"
+  task_delete_success: "タスクを削除しました"
+  task_delete_failed:  "タスクの削除に失敗しました"
+  task_not_exist:      "該当するタスクが存在しません"
+
+  # ビュー
+  save_changes:  '変更を保存'
+  cancel_edit:   '編集をキャンセル'
+  cancel_create: '作成をキャンセル'
+  back_to_index: '一覧に戻る'
+  delete_task:   'タスクを削除'
+  create_task:   'タスクを作成'
+  edit:          '編集'
+  detail:        '詳細'
+
+  # 確認メッセージ
+  message_before_delete: '本当に削除しますか?'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,5 +18,9 @@ ja:
   edit:          '編集'
   detail:        '詳細'
 
+  task_index:  'タスク一覧'
+  task_edit:   'タスク編集'
+  task_create: 'タスク作成'
+
   # 確認メッセージ
   message_before_delete: '本当に削除しますか?'

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,19 @@
+ja:
+  activerecord:
+    models:
+      task: タスク
+    #モデルごとに設定したいattributesを定義
+    attributes:
+      task:
+        name:           タスク名
+        description:    説明
+        start_date:     開始日
+        necessary_days: 必要日数
+        progress:       進行状況
+        priority:       重要度
+        period_on_task: 取り掛かり期間
+
+  # 全てのモデルで共通して使用するattributes
+  attributes:
+    created_at: 作成日時
+    updated_at: 更新日時

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe 'Tasks', type: :system do
     context 'description以外の入力フォームを全て埋めたとき' do
       it 'タスクの作成に成功する' do
         # フォームを埋める
-        fill_in 'タスク名',        with: 'sample task'
-        fill_in '開始日',          with: today
-        fill_in '必要日数',        with: 3
+        fill_in 'タスク名', with: 'sample task'
+        fill_in '開始日', with: today
+        fill_in '必要日数', with: 3
         choose  '未着手'
         choose  '低'
 
@@ -38,9 +38,9 @@ RSpec.describe 'Tasks', type: :system do
     context 'Nameを空のままタスクを作成しようとしたとき' do
       it 'タスクの作成に失敗する' do
         # フォームを埋める
-        fill_in 'タスク名',   with: ''
-        fill_in '開始日',     with: today
-        fill_in '必要日数',   with: 3
+        fill_in 'タスク名', with: ''
+        fill_in '開始日', with: today
+        fill_in '必要日数', with: 3
         choose  '未着手'
         choose  '低'
 
@@ -87,7 +87,7 @@ RSpec.describe 'Tasks', type: :system do
         fill_in      'タスク名', with: ''
         click_button '変更を保存'
 
-        expect(page).to have_content "タスク名を入力してください"
+        expect(page).to have_content 'タスク名を入力してください'
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe 'Tasks', type: :system do
     context 'description以外の入力フォームを全て埋めたとき' do
       it 'タスクの作成に成功する' do
         # フォームを埋める
-        fill_in 'Name',           with: 'sample task'
-        fill_in 'Start date',     with: today
-        fill_in 'Necessary days', with: 3
+        fill_in 'タスク名',        with: 'sample task'
+        fill_in '開始日',          with: today
+        fill_in '必要日数',        with: 3
         choose  '未着手'
         choose  '低'
 
@@ -28,19 +28,19 @@ RSpec.describe 'Tasks', type: :system do
         click_button 'Create'
 
         # 作成成功
-        expect(page).to have_content 'Task Created Successfully!'
+        expect(page).to have_content 'タスクを作成しました'
 
         # indexページにいる
-        expect(page).to have_content 'All tasks'
+        expect(page).to have_content 'タスク一覧'
       end
     end
 
     context 'Nameを空のままタスクを作成しようとしたとき' do
       it 'タスクの作成に失敗する' do
         # フォームを埋める
-        fill_in 'Name',           with: ''
-        fill_in 'Start date',     with: today
-        fill_in 'Necessary days', with: 3
+        fill_in 'タスク名',   with: ''
+        fill_in '開始日',     with: today
+        fill_in '必要日数',   with: 3
         choose  '未着手'
         choose  '低'
 
@@ -48,10 +48,10 @@ RSpec.describe 'Tasks', type: :system do
         click_button 'Create'
 
         # 作成失敗
-        expect(page).to have_content 'Failed to create task'
+        expect(page).to have_content 'タスクの作成に失敗しました'
 
         # newページにいる
-        expect(page).to have_content 'new task'
+        expect(page).to have_content 'タスク作成'
       end
     end
   end
@@ -68,11 +68,11 @@ RSpec.describe 'Tasks', type: :system do
     context 'Nameを書き換えて更新したとき' do
       it '更新に成功する' do
         # 新しい名前にして更新
-        fill_in      'Name', with: 'updated task'
-        click_button 'Save changes'
+        fill_in      'タスク名', with: 'updated task'
+        click_button '変更を保存'
 
         # 更新成功
-        expect(page).to have_content 'Task Updated Successfully!'
+        expect(page).to have_content 'タスクを更新しました'
 
         # 詳細ページにいる
         expect(page).to have_link '一覧に戻る'
@@ -84,10 +84,10 @@ RSpec.describe 'Tasks', type: :system do
 
     context 'Nameを空欄にして更新したとき' do
       it '更新に失敗する' do
-        fill_in      'Name', with: ''
-        click_button 'Save changes'
+        fill_in      'タスク名', with: ''
+        click_button '変更を保存'
 
-        expect(page).to have_content "Name can't be blank"
+        expect(page).to have_content "タスク名を入力してください"
       end
     end
   end
@@ -107,10 +107,10 @@ RSpec.describe 'Tasks', type: :system do
         expect(page.accept_confirm).to eq '本当に削除しますか?'
 
         # 削除成功のメッセージが表示される
-        expect(page).to have_content 'Task deleted Successfully'
+        expect(page).to have_content 'タスクを削除しました'
 
         # 一覧ページにいる
-        expect(page).to have_content 'All tasks'
+        expect(page).to have_content 'タスク一覧'
       end
     end
   end


### PR DESCRIPTION
# 参考
[[初学者]Railsのi18nによる日本語化対応](https://qiita.com/shimadama/items/7e5c3d75c9a9f51abdd5)

# 関連PR
日本語対応したことで、システムテスト(#23) の内容を一部書き換える必要がある。
(例)
```
# 作成成功
    expect(page).to have_content 'Task Created Successfully!'
```
↓
```
# 作成成功
    expect(page).to have_content 'タスクを作成しました'
```