### PR TITLE
pry-byebugをインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,8 +30,8 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i(mri mingw x64_mingw)
   gem 'factory_bot_rails'
-  gem 'rspec-rails'
   gem 'pry-byebug'
+  gem 'rspec-rails'
 
   # Capybara本体
   gem 'capybara'

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'debug', platforms: %i(mri mingw x64_mingw)
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem 'pry-byebug'
 
   # Capybara本体
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.37.1)
       addressable
       matrix
@@ -85,6 +86,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     database_cleaner (2.0.1)
@@ -151,6 +153,12 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.3.5)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -275,6 +283,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails (~> 1.1)
   pg
+  pry-byebug
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)
   retrieva-cop


### PR DESCRIPTION
# 導入理由
デバッグを行いやすくするため