### PR TITLE
テキストフィールドからタスクを検索

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,12 @@ RSpec/MultipleExpectations:
   Exclude:
   - spec/system/*
 
+Metrics/ClassLength:
+  Max: 200
+
+Metrics/AbcSize:
+  Max: 30
+
 AllCops:
   TargetRubyVersion: 3.1
   # comment unless use rails cops

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'turbo-rails'
 
 gem 'rails-i18n'
 
+# ページネーション
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i(mri mingw x64_mingw)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,18 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -285,6 +297,7 @@ DEPENDENCIES
   enum_help
   factory_bot_rails
   importmap-rails (~> 1.1)
+  kaminari
   pg
   pry-byebug
   puma (~> 5.0)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,11 +19,11 @@ class TasksController < ApplicationController
   end
 
   def index
-    if params[:search].present?
-      @tasks = search_task_by_name
-    else
-      @tasks = Task.all
-    end
+    @tasks = if params[:search].present?
+               search_task_by_name
+             else
+               Task.all
+             end
 
     # デフォルトのソート順はid
     sort_by       = params[:sort].presence      || 'id'
@@ -77,8 +77,8 @@ class TasksController < ApplicationController
   end
 
   def search_task_by_name
-    if params[:search_option] == "perfect_match"
-     Task.where(name: params[:search])
+    if params[:search_option] == 'perfect_match'
+      Task.where(name: params[:search])
     else # partial_match
       Task.where('name LIKE ?', "%#{params[:search]}%")
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -21,10 +21,10 @@ class TasksController < ApplicationController
   def index
     # タスクの検索
     searched_tasks = if params[:search].present?
-      search_task_by_name
-    else
-      Task.all
-    end
+                       search_task_by_name
+                     else
+                       Task.all
+                     end
     @shown_search_praceholder = params[:search].presence || 'タスク名'
     @shown_search_option = params[:search_option].presence || 'perfect_match'
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -25,6 +25,9 @@ class TasksController < ApplicationController
                Task.all
              end
 
+    @shown_search_praceholder = params[:search].presence || 'タスク名'
+    @shown_search_option = params[:search_option].presence || 'perfect_match'
+
     # デフォルトのソート順はid
     sort_by       = params[:sort].presence      || 'id'
     direction     = params[:direction].presence || 'ASC'

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,18 +19,16 @@ class TasksController < ApplicationController
   end
 
   def index
-    if params[:name].present?
-      if params[:option] == "perfect_match"
-        @tasks = Task.where(name: params[:name])
-      else # partial_match
-        @tasks = Task.where('name LIKE ?', "%#{params[:name]}%")
-      end
+    if params[:search].present?
+      @tasks = search_task_by_name
     else
-      # デフォルトのソート順はid
-      sort_by       = params[:sort].presence      || 'id'
-      direction     = params[:direction].presence || 'ASC'
-      @tasks = Task.all.order("#{sort_by} #{direction}")
+      @tasks = Task.all
     end
+
+    # デフォルトのソート順はid
+    sort_by       = params[:sort].presence      || 'id'
+    direction     = params[:direction].presence || 'ASC'
+    @tasks = @tasks.order("#{sort_by} #{direction}")
   end
 
   def destroy
@@ -76,5 +74,13 @@ class TasksController < ApplicationController
       return redirect_to tasks_url
     end
     task
+  end
+
+  def search_task_by_name
+    if params[:search_option] == "perfect_match"
+     Task.where(name: params[:search])
+    else # partial_match
+      Task.where('name LIKE ?', "%#{params[:search]}%")
+    end
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,7 +27,7 @@ class TasksController < ApplicationController
                      else
                        Task.all
                      end
-    @shown_search_praceholder = params[:search].presence || 'タスク名'
+    @shown_search_placeholder = params[:search].presence || 'タスク名'
     @shown_search_option = params[:search_option].presence || 'perfect_match'
 
     # タスクのフィルタリング

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -22,11 +22,7 @@ class TasksController < ApplicationController
 
   def index
     # タスクの検索
-    searched_tasks = if params[:search].present?
-                       search_task_by_name
-                     else
-                       Task.all
-                     end
+    searched_tasks = Task.search_task(params[:search], params[:search_option])
     @shown_search_placeholder = params[:search].presence || 'タスク名'
     @shown_search_option = params[:search_option].presence || 'perfect_match'
 
@@ -89,14 +85,6 @@ class TasksController < ApplicationController
       return redirect_to tasks_url
     end
     task
-  end
-
-  def search_task_by_name
-    if params[:search_option] == 'perfect_match'
-      Task.where(name: params[:search])
-    else # partial_match
-      Task.where('name LIKE ?', "%#{params[:search]}%")
-    end
   end
 
   def update_filter_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -20,7 +20,11 @@ class TasksController < ApplicationController
 
   def index
     if params[:name].present?
-      @tasks = Task.where('name LIKE ?', "%#{params[:name]}%")
+      if params[:option] == "perfect_match"
+        @tasks = Task.where(name: params[:name])
+      else # partial_match
+        @tasks = Task.where('name LIKE ?', "%#{params[:name]}%")
+      end
     else
       # デフォルトのソート順はid
       sort_by       = params[:sort].presence      || 'id'

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,10 +19,14 @@ class TasksController < ApplicationController
   end
 
   def index
-    # デフォルトのソート順はid
-    sort_by       = params[:sort].presence      || 'id'
-    direction     = params[:direction].presence || 'ASC'
-    @tasks = Task.all.order("#{sort_by} #{direction}")
+    if params[:name].present?
+      @tasks = Task.where('name LIKE ?', "%#{params[:name]}%")
+    else
+      # デフォルトのソート順はid
+      sort_by       = params[:sort].presence      || 'id'
+      direction     = params[:direction].presence || 'ASC'
+      @tasks = Task.all.order("#{sort_by} #{direction}")
+    end
   end
 
   def destroy

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,6 @@
 class TasksController < ApplicationController
+  TASKS_NUM_PER_PAGE = 10
+
   def new
     @task = Task.new
   end
@@ -33,9 +35,10 @@ class TasksController < ApplicationController
     filtered_tasks = filter_tasks_from_checkbox_params(searched_tasks)
 
     # タスクのソート(デフォルトはidの昇順)
-    sort_by   = params[:sort].presence      || 'id'
-    direction = params[:direction].presence || 'ASC'
-    @tasks    = filtered_tasks.order("#{sort_by} #{direction}")
+    sort_by      = params[:sort].presence      || 'id'
+    direction    = params[:direction].presence || 'ASC'
+    sorted_tasks = filtered_tasks.order("#{sort_by} #{direction}")
+    @tasks       = sorted_tasks.page(params[:page]).per(TASKS_NUM_PER_PAGE)
   end
 
   def destroy

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,4 +16,14 @@ class Task < ApplicationRecord
     '中': 1,
     '高': 2
   }
+
+  scope :search_task, ->(name, option) {
+    if name.blank?
+      Task.all
+    elsif option == 'perfect_match'
+      Task.where(name:)
+    else # partial_match
+      Task.where('name LIKE ?', "%#{name}%")
+    end
+  }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -19,11 +19,11 @@ class Task < ApplicationRecord
 
   scope :search_task, ->(name, option) {
     if name.blank?
-      Task.all
+      all
     elsif option == 'perfect_match'
-      Task.where(name:)
+      where(name:)
     else # partial_match
-      Task.where('name LIKE ?', "%#{name}%")
+      where('name LIKE ?', "%#{name}%")
     end
   }
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,6 +5,8 @@
 <div class="search_form">
   <%= form_with url: tasks_path, method: :get do |f| %>
       <%= f.text_field :name, placeholder: "タスク名" %>
+      <%= f.select :option, options_for_select([["完全に一致", "perfect_match"],
+                                                ["一部を含む", "partial_match"]]) %>
       <%= f.submit '検索', class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -8,8 +8,8 @@
 <div class="search_form">
   <%= form_with url: tasks_path, method: :get do |f| %>
       <%= f.text_field :search, placeholder: @shown_search_placeholder %>
-      <%= f.select :search_option, options_for_select([["完全に一致", "perfect_match"],
-                                                ["一部を含む", "partial_match"]], @shown_search_option) %>
+      <%= f.select :search_option, options_for_select([%w(完全に一致 perfect_match),
+                                                %w(一部を含む partial_match)], @shown_search_option) %>
       <%= f.submit '検索', class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,8 +4,8 @@
 
 <div class="search_form">
   <%= form_with url: tasks_path, method: :get do |f| %>
-      <%= f.text_field :name, placeholder: "タスク名" %>
-      <%= f.select :option, options_for_select([["完全に一致", "perfect_match"],
+      <%= f.text_field :search, placeholder: "タスク名" %>
+      <%= f.select :search_option, options_for_select([["完全に一致", "perfect_match"],
                                                 ["一部を含む", "partial_match"]]) %>
       <%= f.submit '検索', class: "btn btn-primary" %>
   <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,9 +4,9 @@
 
 <div class="search_form">
   <%= form_with url: tasks_path, method: :get do |f| %>
-      <%= f.text_field :search, placeholder: "タスク名" %>
+      <%= f.text_field :search, placeholder: @shown_search_praceholder %>
       <%= f.select :search_option, options_for_select([["完全に一致", "perfect_match"],
-                                                ["一部を含む", "partial_match"]]) %>
+                                                ["一部を含む", "partial_match"]], @shown_search_option) %>
       <%= f.submit '検索', class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,8 +5,6 @@
 <div class="search_form">
   <%= form_with url: tasks_path, method: :get do |f| %>
       <%= f.text_field :name, placeholder: "タスク名" %>
-      <%= f.select :option, options_for_select([["完全に一致", "perfect_match"],
-                                                ["一部を含む", "partial_match"]]) %>
       <%= f.submit '検索', class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -21,6 +21,10 @@
   <%= sort_by '重要度',    'priority'      %>
 </p>
 
+<% if @tasks.empty? %>
+  該当するタスクがありません
+<% end %>
+
 <ul class="tasks">
   <% @tasks.each do |task| %>
     <div class = "task">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,6 +2,15 @@
 <div><%= link_to I18n.t('create_task'), new_task_url %>
 <br>
 
+<div class="search_form">
+  <%= form_with url: tasks_path, method: :get do |f| %>
+      <%= f.text_field :name, placeholder: "タスク名" %>
+      <%= f.select :option, options_for_select([["完全に一致", "perfect_match"],
+                                                ["一部を含む", "partial_match"]]) %>
+      <%= f.submit '検索', class: "btn btn-primary" %>
+  <% end %>
+</div>
+
 <p>
   並び替え
   <br>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -72,3 +72,5 @@
     </div>
   <% end %>
 </ul>
+
+<%= paginate @tasks %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -7,7 +7,7 @@
 
 <div class="search_form">
   <%= form_with url: tasks_path, method: :get do |f| %>
-      <%= f.text_field :search, placeholder: @shown_search_praceholder %>
+      <%= f.text_field :search, placeholder: @shown_search_placeholder %>
       <%= f.select :search_option, options_for_select([["完全に一致", "perfect_match"],
                                                 ["一部を含む", "partial_match"]], @shown_search_option) %>
       <%= f.submit '検索', class: "btn btn-primary" %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,8 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+# spec用のヘルパーメソッドを定義可能
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/create_test_tasks_helper.rb
+++ b/spec/support/create_test_tasks_helper.rb
@@ -1,0 +1,23 @@
+module CreateTestTasksSupport
+  def create_random_tasks_num(num)
+    today = Time.zone.today
+    # テスト用データの作成
+    num.times do |n|
+      name = "test_task_#{n}"
+      start_date = rand(today..(today + 365))
+      necessary_days = rand(1..50)
+      priority = rand(0..2)
+      progress = rand(0..2)
+
+      create(:task, name:,
+                    start_date:,
+                    necessary_days:,
+                    priority:,
+                    progress:)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include CreateTestTasksSupport
+end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -185,12 +185,11 @@ RSpec.describe 'Tasks', type: :system do
 
     context '検索ワードに当てはまるタスクがないとき' do
       it 'メッセージが表示される' do
-
         fill_in 'search', with: 'no_name'
         select '完全に一致', from: :search_option
         click_on '検索'
 
-        expect(page).to have_content "該当するタスクがありません"
+        expect(page).to have_content '該当するタスクがありません'
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe 'Tasks', type: :system do
     let(:today) { Time.zone.today }
     let(:test_size) { 55 }
     let(:tasks_num_per_page) { ApplicationController::TASKS_NUM_PER_PAGE }
+
     before do
       # テスト用データの作成
       test_size.times do |n|
@@ -174,11 +175,11 @@ RSpec.describe 'Tasks', type: :system do
         priority = rand(0..2)
         progress = rand(0..2)
 
-        Task.create(name:,
-                    start_date:,
-                    necessary_days:,
-                    priority:,
-                    progress:)
+        create(:task, name:,
+                      start_date:,
+                      necessary_days:,
+                      priority:,
+                      progress:)
       end
       # タスク一覧ページを表示
       visit tasks_path
@@ -228,6 +229,47 @@ RSpec.describe 'Tasks', type: :system do
         expect(page).to     have_content 'test_task_30'
         expect(page).to     have_content 'test_task_40'
         expect(page).to     have_content 'test_task_50'
+      end
+    end
+  end
+
+  describe 'ページネーション' do
+    let(:today) { Time.zone.today }
+    let(:test_size) { 55 }
+    let(:tasks_num_per_page) { TasksController::TASKS_NUM_PER_PAGE }
+
+    before do
+      # テスト用データの作成
+      test_size.times do |n|
+        name = "test_task_#{n}"
+        start_date = rand(today..(today + 365))
+        necessary_days = rand(1..50)
+        priority = rand(0..2)
+        progress = rand(0..2)
+
+        Task.create(name:,
+                      start_date:,
+                      necessary_days:,
+                      priority:,
+                      progress:)
+      end
+      # タスク一覧ページを表示
+      visit tasks_path
+    end
+
+    context 'indexページを開いたとき' do
+      it 'ページネーションが適用されている' do
+        # 最初のページに表示されている件数を見る
+        expect(page.all('.task').size).to eq(tasks_num_per_page)
+
+        # 最後のページに移動
+        click_on 'Last'
+
+        # 最後のページのタスクを正確に取得するにはsleepが必要
+        sleep 3
+
+        # 最後のページに表示されている件数を見る
+        expect(page.all('.task').size).to eq(test_size % tasks_num_per_page)
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'Tasks', type: :system do
 
         # ページがレンダリングされるのを待つ
         # これがないとStaleElementReferenceErrorが発生
-        sleep 1
+        sleep 2
 
         tasks = page.all('.task')
         expect(tasks[0]).to have_content '高'
@@ -185,12 +185,11 @@ RSpec.describe 'Tasks', type: :system do
 
     context '検索ワードに当てはまるタスクがないとき' do
       it 'メッセージが表示される' do
-
         fill_in 'search', with: 'no_name'
         select '完全に一致', from: :search_option
         click_on '検索'
 
-        expect(page).to have_content "該当するタスクがありません"
+        expect(page).to have_content '該当するタスクがありません'
       end
     end
 
@@ -200,11 +199,34 @@ RSpec.describe 'Tasks', type: :system do
         select '完全に一致', from: :search_option
         click_on '検索'
 
+        sleep 1
+
         # 表示されているタスクは1件で、
         expect(page.all('.task').size).to eq(1)
 
         # それはタスク15である
-        expect(page).to     have_content "test_task_15"
+        expect(page).to have_content 'test_task_15'
+      end
+    end
+
+    context '一部を含むオプションを選んだとき' do
+      it 'タスク名に検索ワードを含むタスク全てが表示される' do
+        fill_in 'search', with: '0'
+        select '一部を含む', from: :search_option
+        click_on '検索'
+
+        sleep 1
+
+        # 表示されているタスクは6件で、
+        expect(page.all('.task').size).to eq(6)
+
+        # それは名前に"0"を含むタスクである
+        expect(page).to     have_content 'test_task_0'
+        expect(page).to     have_content 'test_task_10'
+        expect(page).to     have_content 'test_task_20'
+        expect(page).to     have_content 'test_task_30'
+        expect(page).to     have_content 'test_task_40'
+        expect(page).to     have_content 'test_task_50'
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -159,4 +159,44 @@ RSpec.describe 'Tasks', type: :system do
       end
     end
   end
+
+  describe 'タスクのワード検索' do
+    let(:today) { Time.zone.today }
+    let(:test_size) { 55 }
+    let(:tasks_num_per_page) { ApplicationController::TASKS_NUM_PER_PAGE }
+    before do
+      # テスト用データの作成
+      test_size.times do |n|
+        name = "test_task_#{n}"
+        start_date = rand(today..(today + 365))
+        necessary_days = rand(1..50)
+        priority = rand(0..2)
+        progress = rand(0..2)
+
+        Task.create(name:,
+                    start_date:,
+                    necessary_days:,
+                    priority:,
+                    progress:)
+      end
+      # タスク一覧ページを表示
+      visit tasks_path
+    end
+
+    context 'indexページを開いたとき' do
+      it 'ページネーションが適用されている' do
+        # 最初のページに表示されている件数を見る
+        expect(page.all('.task').size).to eq(tasks_num_per_page)
+
+        # 最後のページに移動
+        click_on 'Last'
+
+        # 最後のページのタスクを正確に取得するにはsleepが必要
+        sleep 3
+
+        # 最後のページに表示されている件数を見る
+        expect(page.all('.task').size).to eq(test_size % tasks_num_per_page)
+      end
+    end
+  end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -185,11 +185,26 @@ RSpec.describe 'Tasks', type: :system do
 
     context '検索ワードに当てはまるタスクがないとき' do
       it 'メッセージが表示される' do
+
         fill_in 'search', with: 'no_name'
         select '完全に一致', from: :search_option
         click_on '検索'
 
-        expect(page).to have_content '該当するタスクがありません'
+        expect(page).to have_content "該当するタスクがありません"
+      end
+    end
+
+    context '完全に一致オプションを選んだとき' do
+      it 'タスク名が全一致するタスクのみ表示される' do
+        fill_in 'search', with: 'test_task_15'
+        select '完全に一致', from: :search_option
+        click_on '検索'
+
+        # 表示されているタスクは1件で、
+        expect(page.all('.task').size).to eq(1)
+
+        # それはタスク15である
+        expect(page).to     have_content "test_task_15"
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -248,10 +248,10 @@ RSpec.describe 'Tasks', type: :system do
         progress = rand(0..2)
 
         Task.create(name:,
-                      start_date:,
-                      necessary_days:,
-                      priority:,
-                      progress:)
+                    start_date:,
+                    necessary_days:,
+                    priority:,
+                    progress:)
       end
       # タスク一覧ページを表示
       visit tasks_path

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Tasks', type: :system do
+  include CreateTestTasksSupport
   describe 'タスクの作成' do
     before do
       # タスク一覧ページを表示
@@ -234,25 +235,11 @@ RSpec.describe 'Tasks', type: :system do
   end
 
   describe 'ページネーション' do
-    let(:today) { Time.zone.today }
-    let(:test_size) { 55 }
     let(:tasks_num_per_page) { TasksController::TASKS_NUM_PER_PAGE }
+    let(:test_size) { 55 }
 
     before do
-      # テスト用データの作成
-      test_size.times do |n|
-        name = "test_task_#{n}"
-        start_date = rand(today..(today + 365))
-        necessary_days = rand(1..50)
-        priority = rand(0..2)
-        progress = rand(0..2)
-
-        Task.create(name:,
-                    start_date:,
-                    necessary_days:,
-                    priority:,
-                    progress:)
-      end
+      create_random_tasks_num test_size
       # タスク一覧ページを表示
       visit tasks_path
     end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Tasks', type: :system do
     end
   end
 
-  describe 'タスクのワード検索' do
+  describe 'タスクを名前で検索する' do
     let(:today) { Time.zone.today }
     let(:test_size) { 55 }
     let(:tasks_num_per_page) { ApplicationController::TASKS_NUM_PER_PAGE }
@@ -183,19 +183,14 @@ RSpec.describe 'Tasks', type: :system do
       visit tasks_path
     end
 
-    context 'indexページを開いたとき' do
-      it 'ページネーションが適用されている' do
-        # 最初のページに表示されている件数を見る
-        expect(page.all('.task').size).to eq(tasks_num_per_page)
+    context '検索ワードに当てはまるタスクがないとき' do
+      it 'メッセージが表示される' do
 
-        # 最後のページに移動
-        click_on 'Last'
+        fill_in 'search', with: 'no_name'
+        select '完全に一致', from: :search_option
+        click_on '検索'
 
-        # 最後のページのタスクを正確に取得するにはsleepが必要
-        sleep 3
-
-        # 最後のページに表示されている件数を見る
-        expect(page.all('.task').size).to eq(test_size % tasks_num_per_page)
+        expect(page).to have_content "該当するタスクがありません"
       end
     end
   end


### PR DESCRIPTION
# やったこと
- 検索用のテキストフィールドと検索ボタンを配置
- 「完全に一致」と「一部を含む」プルダウンを配置
- 「完全に一致」を選んだとき、タスク名が検索ワードに等しいタスクのみが表示される
- 「一部を含む」を選んだとき、タスク名に検索ワードを含むタスク全てが表示される

## 参考
検索機能の実装
https://qiita.com/hapiblog2020/items/6c2cef49df5616da9ae3

Rspecで使用するヘルパーメソッドの作成方法
http://www.code-magagine.com/?p=9754